### PR TITLE
Add newline after every event

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -331,7 +331,7 @@ where
                 }
 
                 write.write_all(entry.dump().as_bytes()).unwrap();
-                write.write_all(b",").unwrap();
+                write.write_all(b",\n").unwrap();
             }
         });
 


### PR DESCRIPTION
Implements #2 

This change adds a newline after every event to make it easier to deal with large captures. When running I'm constantly generated multiple gigabyte files and need to trim them down before chrome will accept it.

With a newline between each event, its easy to just use `tail -n 100000 trace.*.json` to get the finall 100,000 events.

The added overhead of an extra byte per event is pretty small. As an example a 1,888 MB file changes to 1,898 MB.