### PR TITLE
Modify values when a record event is found

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,6 +484,23 @@ where
         self.enter_span(ctx.span(id).expect("Span not found."), ts);
     }
 
+    fn on_record(&self, id: &span::Id, values: &span::Record<'_>, ctx: Context<'_, S>) {
+        if self.include_args {
+            let span = ctx.span(id).unwrap();
+            let mut exts = span
+                .extensions_mut();
+
+            let args = exts
+                .get_mut::<ArgsWrapper>();
+
+            if let Some(args) = args {
+                let args = Arc::make_mut(&mut args.args);
+                values.record(&mut JsonVisitor { object: args });
+            }
+
+        }
+    }
+
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
         let ts = self.get_ts();
         let callsite = self.get_callsite(EventOrSpan::Event(event));


### PR DESCRIPTION
This pull requests implements the `Layer.on_record` method on `ChromeLayer`.
This fixes a bug where the following:
```rust
let span = span!(
        Level::DEBUG,
       "test",
        index = -1
);
span.record("index", 12);
```
Would record an "exit" event where the "index" values would still be `-1` instead of `12`