### PR TITLE
Directly depend on crossbeam_channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 repository = "https://github.com/thoren-d/tracing-chrome"
 
 [dependencies]
-crossbeam = "0.8.1"
+crossbeam-channel = "0.5.6"
 json = "0.12.4"
 tracing = "0.1.21"
 tracing-subscriber = "0.3.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ tracing_subscriber::registry().with(chrome_layer).init();
 
 */
 
-use crossbeam::channel::Sender;
+use crossbeam_channel::Sender;
 
 use tracing::{span, Event, Subscriber};
 use tracing_subscriber::{
@@ -268,7 +268,7 @@ where
     S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
 {
     fn new(mut builder: ChromeLayerBuilder<S>) -> (ChromeLayer<S>, FlushGuard) {
-        let (tx, rx) = crossbeam::channel::unbounded();
+        let (tx, rx) = crossbeam_channel::unbounded();
         OUT.with(|val| val.replace(Some(tx.clone())));
 
         let out_writer = builder.out_writer.unwrap_or_else(|| {


### PR DESCRIPTION
Instead of the umbrella crate "crossbeam". This reduces the total number of dependencies.