### PR TITLE
change scope of instant events to thread

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,7 +334,7 @@ where
                     }
 
                     if ph == "i" {
-                        entry.insert("s", "p".into());
+                        entry.insert("s", "t".into());
                     }
 
                     let mut args = Object::new();


### PR DESCRIPTION
This pull request changes emitted json for `event!` to use thread-scoped instant instead of process-scoped one.

## Context

When loading trace in [ui.perfetto.dev](https://ui.perfetto.dev) and clicking on the arrow representing the event, the ui fails to show any arguments. While investigating this I discovered [a spec for the trace format](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit#) which states that
> Process-scoped and global-scoped events do not support stack traces at this time.
it says nothing about arguments, but it clearly also does not support them. I tried changing it and it has  two effects:
1. it shows the arguments correctly
2. the arrow is moved from separate track into the same track as other spans from same thread.

Only downside I could find is that chrome://tracing (which pointed me to perfetto in the first place) displays this as a shorter line, which might be suboptimal for some events. It's okay for my usecase, but I don't really want to use the chrome built-in viewer anyway - I find it less intuitive to navigate.

Anyway, thanks for an awesome project which allowed me to glean some insight into my program without having to read long logs 🙂 