### PR TITLE
Save thread names for start_new

### DIFF
--- a/examples/fibonacci.rs
+++ b/examples/fibonacci.rs
@@ -48,4 +48,10 @@ fn main() {
     let before = std::time::Instant::now();
     println!("fibonacci_parallel(24) -> {}", fibonacci_parallel(24));
     println!("took {} s", before.elapsed().as_secs_f32());
+    if let Some(guard) = &guard {
+        guard.start_new(None);
+    }
+    let before = std::time::Instant::now();
+    println!("fibonacci_parallel(20) -> {}", fibonacci_parallel(20));
+    println!("took {} s", before.elapsed().as_secs_f32());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -325,7 +325,7 @@ where
                         entry.insert("ph", "M".to_string().into());
                         entry.insert("pid", 1.into());
                         entry.insert("name", "thread_name".to_string().into());
-                        entry.insert("tid", tid.clone().into());
+                        entry.insert("tid", (*tid).into());
                         let mut args = Object::new();
                         args.insert("name", name.clone().into());
                         entry.insert("args", args.into());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -288,7 +288,6 @@ impl<S> ChromeLayer<S>
 where
     S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync,
 {
-
     fn new(mut builder: ChromeLayerBuilder<S>) -> (ChromeLayer<S>, FlushGuard) {
         let (tx, rx) = crossbeam_channel::unbounded();
         OUT.with(|val| val.replace(Some(tx.clone())));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,7 +278,7 @@ fn create_default_writer() -> Box<dyn Write + Send> {
             std::time::SystemTime::UNIX_EPOCH
                 .elapsed()
                 .unwrap()
-                .as_secs()
+                .as_micros()
         ))
         .expect("Failed to create trace file."),
     )
@@ -301,6 +301,7 @@ where
             write.write_all(b"[\n").unwrap();
 
             let mut has_started = false;
+            let mut thread_names: Vec<(u64, String)> = Vec::new();
             for msg in rx {
                 if let Message::Flush = &msg {
                     write.flush().unwrap();
@@ -317,6 +318,23 @@ where
                     write = BufWriter::new(out_writer);
                     write.write_all(b"[\n").unwrap();
                     has_started = false;
+
+                    // Write saved thread names
+                    for (tid, name) in thread_names.iter() {
+                        let mut entry = Object::new();
+                        entry.insert("ph", "M".to_string().into());
+                        entry.insert("pid", 1.into());
+                        entry.insert("name", "thread_name".to_string().into());
+                        entry.insert("tid", tid.clone().into());
+                        let mut args = Object::new();
+                        args.insert("name", name.clone().into());
+                        entry.insert("args", args.into());
+                        if has_started {
+                            write.write_all(b",\n").unwrap();
+                        }
+                        write.write_all(entry.dump().as_bytes()).unwrap();
+                        has_started = true;
+                    }
                     continue;
                 }
 
@@ -341,6 +359,7 @@ where
                 entry.insert("pid", 1.into());
 
                 if let Message::NewThread(tid, name) = msg {
+                    thread_names.push((tid, name.clone()));
                     entry.insert("name", "thread_name".to_string().into());
                     entry.insert("tid", tid.into());
                     let mut args = Object::new();


### PR DESCRIPTION
Before, new traces created through start_new would be missing the thread
names. Now we save tid->name mappings when a new thread is discovered,
and write all the saved entries when starting a new trace.