### PR TITLE
Remove brackets from arg names for perfetto.dev compatibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -382,8 +382,8 @@ where
 
                     let mut args = Object::new();
                     if let (Some(file), Some(line)) = (callsite.file, callsite.line) {
-                        args.insert("[file]", file.to_string().into());
-                        args.insert("[line]", line.into());
+                        args.insert(".file", file.to_string().into());
+                        args.insert(".line", line.into());
                     }
 
                     if let Some(call_args) = &callsite.args {


### PR DESCRIPTION
Apparently with the new Perfetto UI, arg names with brackets are not displayed properly. Removing the brackets fixes the issue.

<img width="1040" alt="Screen Shot 2022-11-23 at 5 08 59 PM" src="https://user-images.githubusercontent.com/230691/203554759-6f3be494-82a2-4703-9681-d03790d6f77d.png">
