### PR TITLE
Disable unused features of tracing-subscriber

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/thoren-d/tracing-chrome"
 [dependencies]
 serde_json = "1.0.114"
 tracing-core = "0.1.32"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", default-features = false, features = ["std"] }
 
 
 [dev-dependencies]


### PR DESCRIPTION
I believe that the tracing-subscriber's default features are unnecessary.
This PR removes all default features except for 'std'.